### PR TITLE
Split workflow into multiple jobs.  Add artifact output.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,31 +4,53 @@ name: build
 on: [push]
 
 jobs:
-  build:
-
+  lint:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v1
-
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+      - uses: actions/setup-python@v1
         with:
           python-version: 3.7
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade -r requirements-test.txt
-
-      - name: Run pre-commit on all files
+      - name: Run linters on all files
         run: pre-commit run --all-files
-
-      - name: Test with pytest
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade -r requirements-test.txt
+      - name: Run tests
         run: pytest
-
-      - name: Coveralls
+      - name: Upload coverage report
         run: coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         if: success()
+  build:
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip wheel
+          pip install --upgrade -r requirements.txt
+      - name: Build artifacts
+        run: python3 setup.py sdist bdist_wheel
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: dist
+          path: dist


### PR DESCRIPTION
Splits up the workflow into a few jobs with dependencies.  
This workflow will now save an artifact.

See: https://help.github.com/en/github/automating-your-workflow-with-github-actions/persisting-workflow-data-using-artifacts