### PR TITLE
Pull upstream changes from skeleton-generic.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v2.4.0
     hooks:
       - id: check-executables-have-shebangs
       - id: check-json
@@ -23,7 +23,7 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.18.0
+    rev: v0.19.0
     hooks:
       - id: markdownlint
         args:
@@ -37,13 +37,13 @@ repos:
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.8
+    rev: 3.7.9
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.25.0
+    rev: v1.25.1
     hooks:
       - id: pyupgrade
   # Run bandit on "tests" tree with a configuration
@@ -63,11 +63,11 @@ repos:
         name: bandit (everything else)
         exclude: tests
   - repo: https://github.com/python/black
-    rev: 19.3b0
+    rev: 19.10b0
     hooks:
       - id: black
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v4.1.1a0
+    rev: v4.1.1a3
     hooks:
       - id: ansible-lint
         # files: molecule/default/playbook.yml

--- a/setup.py
+++ b/setup.py
@@ -68,15 +68,7 @@ setup(
     py_modules=[splitext(basename(path))[0] for path in glob("src/*.py")],
     include_package_data=True,
     install_requires=["docopt", "setuptools"],
-    extras_require={
-        "test": [
-            "pre-commit",
-            "pytest",
-            "pytest-cov",
-            "coveralls",
-            "virtualenv==16.3.0",  # see: https://github.com/ansible/ansible-lint/issues/590
-        ]
-    },
+    extras_require={"test": ["pre-commit", "pytest", "pytest-cov", "coveralls"]},
     # Conveniently allows one to run the CLI tool as `example`
     entry_points={"console_scripts": ["example = example.example:main"]},
 )


### PR DESCRIPTION
Pull in upstream changes to pre-commit versions. This was done specifically because of a bug in flake8 referenced in the upstream PR https://github.com/cisagov/skeleton-generic/pull/21

Also removed the virtualenv pinning as noted in #21 as that ansible-lint issue was resolved upstream.