### PR TITLE
Add Scripts for Bumping Versions and Tagging

### DIFF
--- a/bump_version.sh
+++ b/bump_version.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# bump_version.sh (show|major|minor|patch|prerelease|build)
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+VERSION_FILE=src/example/_version.py
+
+HELP_INFORMATION="bump_version.sh (show|major|minor|patch|prerelease|build|finalize)"
+
+old_version=$(sed -n "s/^__version__ = \"\(.*\)\"$/\1/p" $VERSION_FILE)
+
+if [ $# -ne 1 ]
+then
+   echo "$HELP_INFORMATION"
+else
+    case $1 in
+        major|minor|patch|prerelease|build)
+            new_version=$(python -c "import semver; print(semver.bump_$1('$old_version'))")
+            echo Changing version from "$old_version" to "$new_version"
+            tmp_file=/tmp/version.$$
+            sed "s/$old_version/$new_version/" $VERSION_FILE > $tmp_file
+            mv $tmp_file $VERSION_FILE
+            git add $VERSION_FILE
+            git commit -m"Bump version from $old_version to $new_version"
+            git push
+            ;;
+        finalize)
+            new_version=$(python -c "import semver; print(semver.finalize_version('$old_version'))")
+            echo Changing version from "$old_version" to "$new_version"
+            tmp_file=/tmp/version.$$
+            sed "s/$old_version/$new_version/" $VERSION_FILE > $tmp_file
+            mv $tmp_file $VERSION_FILE
+            git add $VERSION_FILE
+            git commit -m"Bump version from $old_version to $new_version"
+            git push
+            ;;
+        show)
+            echo "$old_version"
+            ;;
+        *)
+            echo "$HELP_INFORMATION"
+            ;;
+    esac
+fi

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -20,6 +20,8 @@ else
         major|minor|patch|prerelease|build)
             new_version=$(python -c "import semver; print(semver.bump_$1('$old_version'))")
             echo Changing version from "$old_version" to "$new_version"
+            # A temp file is used to provide compatability with macOS development
+            # as a result of macOS using the BSD version of sed
             tmp_file=/tmp/version.$$
             sed "s/$old_version/$new_version/" $VERSION_FILE > $tmp_file
             mv $tmp_file $VERSION_FILE
@@ -30,6 +32,8 @@ else
         finalize)
             new_version=$(python -c "import semver; print(semver.finalize_version('$old_version'))")
             echo Changing version from "$old_version" to "$new_version"
+            # A temp file is used to provide compatability with macOS development
+            # as a result of macOS using the BSD version of sed
             tmp_file=/tmp/version.$$
             sed "s/$old_version/$new_version/" $VERSION_FILE > $tmp_file
             mv $tmp_file $VERSION_FILE

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 -r requirements-test.txt
 ipython
+semver

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     package_data={"example": ["data/*.txt"]},
     py_modules=[splitext(basename(path))[0] for path in glob("src/*.py")],
     include_package_data=True,
-    install_requires=["docopt", "setuptools"],
+    install_requires=["docopt", "semver", "setuptools"],
     extras_require={
         "test": [
             "pre-commit",

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,6 @@ setup(
             "coverage < 5.0",
             "pytest-cov",
             "pytest",
-            "semver",
         ]
     },
     # Conveniently allows one to run the CLI tool as `example`

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     package_data={"example": ["data/*.txt"]},
     py_modules=[splitext(basename(path))[0] for path in glob("src/*.py")],
     include_package_data=True,
-    install_requires=["docopt", "semver", "setuptools"],
+    install_requires=["docopt", "setuptools"],
     extras_require={
         "test": [
             "pre-commit",
@@ -80,6 +80,7 @@ setup(
             "coverage < 5.0",
             "pytest-cov",
             "pytest",
+            "semver",
         ]
     },
     # Conveniently allows one to run the CLI tool as `example`

--- a/tag.sh
+++ b/tag.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+version=$(./bump_version.sh show)
+
+git tag "v$version" && git push --tags


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR adds the `bump_version.sh` and `tag.sh` scripts to allow easy version bumping and tagging for Python projects. The `semver` package was also added as a requirement since it is used by `bump_version.sh`.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
Versions and tags are used for marking a release point, and these helper scripts are already in use to that end in some Python projects we have. I thought it would be useful to add it to `skeleton-python-library` so that all Python projects will be able to leverage that functionality.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
Verified that the version was correctly retrieved with `bump_version.sh show`. Since these scripts are in use in other projects I assume other functionality will work correctly.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
