### PR TITLE
Add python_requires argument for setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
     ],
+    python_requires=">=3.6",
     # What does your project relate to?
     keywords="skeleton",
     packages=find_packages(where="src"),
@@ -69,7 +70,7 @@ setup(
     package_data={"example": ["data/*.txt"]},
     py_modules=[splitext(basename(path))[0] for path in glob("src/*.py")],
     include_package_data=True,
-    install_requires=["docopt", "setuptools"],
+    install_requires=["docopt", "setuptools >= 24.2.0"],
     extras_require={
         "test": [
             "pre-commit",


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR adds the `python_requires` argument to `setup()` in `setup.py`. This allows us to specify the version(s) of Python a package's installation environment should have installed to eliminate install conflicts. A version specifier for `setuptools` was added to support the addition of `python_requires`.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
This change was the suggestion of @felddy and makes sense to help improve our Python packages. This will prevent accidental installs in incompatible environments which will prevent such incompatibilities from coming to light at run time.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I attempted to install this package in a `pyenv` venv that did not meet the `python_requires` version and it failed. Installation in a venv with an appropriate Python version was successful.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
