### PR TITLE
Add static type checking to the Python skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-*.egg-info
 __pycache__
-.python-version
 .coverage
+.mypy_cache
 .pytest_cache
+.python-version
+*.egg-info

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.26.2
+    rev: v2.0.0
     hooks:
       - id: pyupgrade
   # Run bandit on "tests" tree with a configuration
@@ -84,7 +84,7 @@ repos:
     rev: v4.2.0
     hooks:
       - id: ansible-lint
-        # files: molecule/default/playbook.yml
+      # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
     rev: v1.12.0
     hooks:
@@ -98,3 +98,7 @@ repos:
     rev: 1.19.1
     hooks:
       - id: prettier
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.761
+    hooks:
+      - id: mypy

--- a/src/example/example.py
+++ b/src/example/example.py
@@ -25,6 +25,7 @@ Options:
 import logging
 import os
 import sys
+from typing import Any, Dict
 
 # Third-Party Libraries
 import docopt
@@ -33,10 +34,10 @@ from schema import And, Schema, SchemaError, Use
 
 from ._version import __version__
 
-DEFAULT_ECHO_MESSAGE = "Hello World from the example default!"
+DEFAULT_ECHO_MESSAGE: str = "Hello World from the example default!"
 
 
-def example_div(dividend, divisor):
+def example_div(dividend: float, divisor: float) -> float:
     """Print some logging messages."""
     logging.debug("This is a debug message")
     logging.info("This is an info message")
@@ -46,11 +47,11 @@ def example_div(dividend, divisor):
     return dividend / divisor
 
 
-def main():
+def main() -> int:
     """Set up logging and call the example function."""
-    args = docopt.docopt(__doc__, version=__version__)
+    args: Dict[str, str] = docopt.docopt(__doc__, version=__version__)
     # Validate and convert arguments as needed
-    schema = Schema(
+    schema: Schema = Schema(
         {
             "--log-level": And(
                 str,
@@ -70,16 +71,16 @@ def main():
     )
 
     try:
-        args = schema.validate(args)
+        validated_args: Dict[str, Any] = schema.validate(args)
     except SchemaError as err:
         # Exit because one or more of the arguments were invalid
         print(err, file=sys.stderr)
         return 1
 
     # Assign validated arguments to variables
-    dividend = args["<dividend>"]
-    divisor = args["<divisor>"]
-    log_level = args["--log-level"]
+    dividend: int = validated_args["<dividend>"]
+    divisor: int = validated_args["<divisor>"]
+    log_level: str = validated_args["--log-level"]
 
     # Set up logging
     logging.basicConfig(
@@ -89,11 +90,11 @@ def main():
     logging.info(f"{dividend} / {divisor} == {example_div(dividend, divisor)}")
 
     # Access some data from an environment variable
-    message = os.getenv("ECHO_MESSAGE", DEFAULT_ECHO_MESSAGE)
+    message: str = os.getenv("ECHO_MESSAGE", DEFAULT_ECHO_MESSAGE)
     logging.info(f'ECHO_MESSAGE="{message}"')
 
     # Access some data from our package data (see the setup.py)
-    secret_message = (
+    secret_message: str = (
         pkg_resources.resource_string("example", "data/secret.txt")
         .decode("utf-8")
         .strip()


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

<!--- Describe your changes in detail -->

**Static type hinting is optional.  Don't freak.**

Add [PEP 484](https://www.python.org/dev/peps/pep-0484/) type hints to the example. 
Add [mypy](https://github.com/python/mypy) static type checker to the pre-commit hooks.

Once/If this is approved, I will backport the `pre-commit` and `.gitignore` changes to the generic skeleton. 

## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I can across a section of the [18-F Python development guide](https://engineering.18f.gov/python/) that discussed static checking.  There are a lot of upsides to type hinting and few downsides.  Also I miss the safety of a statically-typed language. 

As mentioned in the 18-F guide (and soon our own): 

> ...It’s reasonable to default to using type annotations when they make your intent clearer (i.e. as a form of documentation). We suggest using a static analysis tool to catch logic bugs, but only where it’s practical. 

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Previous tests pass.
Added `mypy` to the pre-commit linters.  It will throw errors and warnings if type hints are used and violated.  Otherwise it should be a no-op.

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
