### PR TITLE
Remove or Explain Manual Testing Check Disables

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,7 @@ def get_version(version_file):
         if line.startswith("__version__"):
             delim = '"' if '"' in line else "'"
             return line.split(delim)[1]
-    else:
-        raise RuntimeError("Unable to find version string.")
+    raise RuntimeError("Unable to find version string.")
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,9 @@ Based on:
 """
 
 # Standard Python Libraries
+import codecs
 from glob import glob
-from os.path import basename, splitext
+from os.path import abspath, basename, dirname, join, splitext
 
 # Third-Party Libraries
 from setuptools import find_packages, setup
@@ -22,18 +23,29 @@ def readme():
         return f.read()
 
 
-def package_vars(version_file):
-    """Read in and return the variables defined by the version_file."""
-    pkg_vars = {}
-    with open(version_file) as f:
-        exec(f.read(), pkg_vars)  # nosec
-    return pkg_vars
+# Below two methods were pulled from:
+# https://packaging.python.org/guides/single-sourcing-package-version/
+def read(rel_path):
+    """Open a file for reading from a given relative path."""
+    here = abspath(dirname(__file__))
+    with codecs.open(join(here, rel_path), "r") as fp:
+        return fp.read()
+
+
+def get_version(version_file):
+    """Extract a version number from the given file path."""
+    for line in read(version_file).splitlines():
+        if line.startswith("__version__"):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    else:
+        raise RuntimeError("Unable to find version string.")
 
 
 setup(
     name="example",
     # Versions should comply with PEP440
-    version=package_vars("src/example/_version.py")["__version__"],
+    version=get_version("src/example/_version.py"),
     description="Example python library",
     long_description=readme(),
     long_description_content_type="text/markdown",

--- a/src/example/__init__.py
+++ b/src/example/__init__.py
@@ -1,4 +1,8 @@
 """The example library."""
+# We disable a Flake8 check for "Module imported but unused (F401)" here because
+# although this import is not directly used, it populates the value
+# package_name.__version__, which is used to get version information about this
+# Python package.
 from ._version import __version__  # noqa: F401
 from .example import example_div
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR changes the code in `setup.py` used to get version information and adds a comment explaining why a Flake8 check is disabled. This closes #58 .
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and Context ##

This project had two check disabling comments with no explanation: one each for Bandit and Flake8. The lines of code in question needed to either be changed to remove the need for disabling a check, or to have a comment explaining why the check disable was required. I felt it was better to refactor the code to remove the need for the Bandit check to be disabled. However the piece of code that needs a Flake8 check disabled is the most straightforward way to handle how we implement a Single Source of Truth for package versioning.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
