### PR TITLE
Update coveralls-python Configuration in GitHub Actions Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,9 +75,39 @@ jobs:
       - name: Upload coverage report
         run: coveralls
         env:
+          COVERALLS_FLAG_NAME: "py${{ matrix.python-version }}"
+          COVERALLS_PARALLEL: true
           COVERALLS_SERVICE_NAME: github
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: success()
+  coveralls-finish:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v2
+      - id: setup-python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - uses: actions/cache@v2
+        env:
+          BASE_CACHE_KEY: "${{ github.job }}-${{ runner.os }}-\
+            py${{ steps.setup-python.outputs.python-version }}-"
+        with:
+          path: ${{ env.PIP_CACHE_DIR }}
+          key: "${{ env.BASE_CACHE_KEY }}\
+            ${{ hashFiles('**/requirements-test.txt') }}-\
+            ${{ hashFiles('**/requirements.txt') }}"
+          restore-keys: |
+            ${{ env.BASE_CACHE_KEY }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade --requirement requirements-test.txt
+      - name: Finished coveralls reports
+        run: coveralls --finish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build:
     runs-on: ubuntu-latest
     needs: [lint, test]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,8 @@ jobs:
       - name: Upload coverage report
         run: coveralls
         env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          COVERALLS_SERVICE_NAME: github
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: success()
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates the configuration for [`coveralls-python`](https://github.com/TheKevJames/coveralls-python) in our GitHub Actions workflow to use the automatically created `GITHUB_TOKEN` secret instead of a per-repo `COVERALLS_REPO_TOKEN` we have used previously to close #70. It also tags each individual `test` job (one per Python version supported) at https://coveralls.io by changing our configuration to reflect that the job runs in parallel.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

@dav3r ran into an issue with how [`coveralls-python`](https://github.com/TheKevJames/coveralls-python) is run in our GitHub Actions workflow in https://github.com/cisagov/gophish-tools/pull/29. He determined the fix was the update the configuration to what was described in [the documentation](https://docs.github.com/en/actions/reference/authentication-in-a-workflow). I believe we have run afoul of changes in [`coveralls-python` v3](https://github.com/TheKevJames/coveralls-python/releases/tag/3.0.0) to the order in which configurations are processed.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests run without issue, and I confirmed both that coverage reports were uploaded and that the tagging for parallel tasks is working.
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
