### PR TITLE
Modernize the `build` step in the `build` workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,12 +224,12 @@ jobs:
             ${{ hashFiles('setup.py') }}"
           restore-keys: |
             ${{ env.BASE_CACHE_KEY }}
-      - name: Install dependencies
+      - name: Install build dependencies
         run: |
-          python -m pip install --upgrade pip wheel
-          pip install --upgrade --requirement requirements.txt
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade build
       - name: Build artifacts
-        run: python3 setup.py sdist bdist_wheel
+        run: python -m build
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__
 .pytest_cache
 .python-version
 *.egg-info
+dist


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the `build` step of the `build` workflow to use a more modern process to build the bdist/sdist for a Python package. It also adds `dist` to the `.gitignore` file to more cleanly support local building.  
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Building Python packages with the `setup.py install` method has been deprecated for a while now so we should update our package building process to align with PyPa's [current process](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#packaging-your-project).
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified that the artifact contains both a bdist (wheel) and sdist.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
