### PR TITLE
Improve testing dependency installation in the `test-build` job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -289,12 +289,14 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: dist-${{ matrix.python-version }}
-      - name: Install testing dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools wheel
-          python -m pip install --upgrade pytest pytest-cov
-      - name: Install the built wheel (there should only be one)
-        run: python -m pip install *.whl
+          path: dist
+      - id: find-wheel
+        name: Get the name of the retrieved wheel (there should only be one)
+        run: echo "wheel=$(ls dist/*whl)" >> $GITHUB_OUTPUT
+      - name: Update core Python packages
+        run: python -m pip install --upgrade pip setuptools wheel
+      - name: Install the built wheel
+        run: python -m pip install ${{ steps.find-wheel.outputs.wheel }}
       - name: Run tests
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,8 +295,8 @@ jobs:
         run: echo "wheel=$(ls dist/*whl)" >> $GITHUB_OUTPUT
       - name: Update core Python packages
         run: python -m pip install --upgrade pip setuptools wheel
-      - name: Install the built wheel
-        run: python -m pip install ${{ steps.find-wheel.outputs.wheel }}
+      - name: Install the built wheel (along with testing dependencies)
+        run: python -m pip install ${{ steps.find-wheel.outputs.wheel }}[test]
       - name: Run tests
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request improves the installation of testing dependencies when using a built wheel in the `test-build` job of the `build` workflow. Thanks to @jsf9k for bringing this to my attention as I forgot the possible downstream implications during the initial implementation in #116.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Currently the necessary requirements must be manually specified in the appropriate job step. This is cumbersome as it must be updated for each downstream repository and then if there are changes made in the package's testing requirements they must be updated both in the package dependencies and in the GitHub Actions workflow. Instead we install the optional `test` dependencies of the package as part of installing the wheel to ensure whatever testing dependencies exist for the package are installed.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
