### PR TITLE
Improve job names for the `build` workflow in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,6 +103,7 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE
   test:
+    name: test source - py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -195,6 +196,7 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE
   build:
+    name: build wheel - py${{ matrix.python-version }}
     needs:
       - lint
       - test
@@ -248,6 +250,7 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE
   test-build:
+    name: test built wheel - py${{ matrix.python-version }}
     needs:
       - build
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,10 +195,10 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE
   build:
-    runs-on: ${{ matrix.os }}
     needs:
       - lint
       - test
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -248,9 +248,9 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE
   test-build:
-    runs-on: ${{ matrix.os }}
     needs:
       - build
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request improves the names for the `test`, `build`, and `test-build` jobs as displayed in the GitHub web UI. It also sorts all pre-`steps` keys in a job in descending alphabetical order.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The key sorting is adjusted to stick as reasonably close to our preference to sort all YAML map keys in alphabetically descending order. Since the `steps` key is the meat of the job and everything else is configuration it makes sense to have the `steps` key last and sort everything preceding it in descending alphabetical order.

The job names are updates to both be more descriptive and with the modifications that were required to continue supporting Python 3.6 to make them prettier compared to the auto-generated name using the matrix values.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. You can see the now ✨fabulous✨ output in [this run log](https://github.com/cisagov/skeleton-python-library/actions/runs/4087195087).
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
