### PR TITLE
Add support for Python version 3.12 in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,6 +119,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
         include:
           - os: ubuntu-20.04
             python-version: "3.6"
@@ -215,6 +216,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
         include:
           - os: ubuntu-20.04
             python-version: "3.6"
@@ -268,6 +270,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
         include:
           - os: ubuntu-20.04
             python-version: "3.6"

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: Implementation :: CPython",
     ],
     python_requires=">=3.6",


### PR DESCRIPTION
## 🗣 Description ##

This pull request upgrades a GitHub Actions workflow to take advantage of the latest minor version of Python.

## 💭 Motivation and context ##

Note that these instances _will not_ be updated via the upstream pull
request cisagov/skeleton-generic#154.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.