### PR TITLE
Fix the dependabot ignore directive for `github/codeql-action`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,9 +22,7 @@ updates:
       # # Managed by cisagov/skeleton-python-library
       # - dependency-name: actions/download-artifact
       # - dependency-name: actions/upload-artifact
-      # - dependency-name: github/codeql-action/analyze
-      # - dependency-name: github/codeql-action/autobuild
-      # - dependency-name: github/codeql-action/init
+      # - dependency-name: github/codeql-action
     package-ecosystem: github-actions
     schedule:
       interval: weekly


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request correct the dependabot ignore directive for the [github/codeql-action] Action.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

When I originally created the ignore directives in #127 I erroneously had each sub-Action as its own dependency. However, they are all versioned under the `github/codeql-action` namespace. Therefore in downstream repositories the ignore directives do not correctly register and dependabot will continue to create/leave open PRs to update the [github/codeql-action] Action.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[github/codeql-action]: https://github.com/github/codeql-action