### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,12 +175,10 @@ jobs:
     name: test source - py${{ matrix.python-version }}
     needs:
       - diagnostics
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
         python-version:
           - "3.7"
           - "3.8"
@@ -188,9 +186,6 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-        include:
-          - os: ubuntu-20.04
-            python-version: "3.6"
     steps:
       - id: harden-runner
         name: Harden the runner
@@ -286,12 +281,10 @@ jobs:
       - diagnostics
       - lint
       - test
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
         python-version:
           - "3.7"
           - "3.8"
@@ -299,9 +292,6 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-        include:
-          - os: ubuntu-20.04
-            python-version: "3.6"
     steps:
       - id: harden-runner
         name: Harden the runner
@@ -346,12 +336,10 @@ jobs:
     needs:
       - diagnostics
       - build
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
         python-version:
           - "3.7"
           - "3.8"
@@ -359,9 +347,6 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-        include:
-          - os: ubuntu-20.04
-            python-version: "3.6"
     steps:
       - id: harden-runner
         name: Harden the runner

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,6 @@ setup(
         # that you indicate whether you support Python 2, Python 3 or both.
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -84,7 +83,7 @@ setup(
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: Implementation :: CPython",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     # What does your project relate to?
     keywords="skeleton",
     packages=find_packages(where="src"),

--- a/src/example/_version.py
+++ b/src/example/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request drops support for Python 3.6.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Although it's helpful to support older versions as long as possible it no longer makes sense to support this version of Python given the following:
- Python 3.6 reached end-of-life on 2021-12-23.
- The oldest supported version of Python is 3.8.
- The oldest Python we need support for is 3.7.
  - This is because 3.7 is the version of Python 3 available on Debian Buster.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release.
