### PR TITLE
Add the `--non-interactive` flag when installing type stubs via `mypy`

### DIFF
--- a/setup-env
+++ b/setup-env
@@ -250,9 +250,6 @@ for req_file in "requirements-dev.txt" "requirements-test.txt" "requirements.txt
   fi
 done
 
-# Install all necessary mypy type stubs
-mypy --install-types --non-interactive src/
-
 # Install git pre-commit hooks now or later.
 pre-commit install ${INSTALL_HOOKS:+"--install-hooks"}
 
@@ -284,6 +281,9 @@ else:
     print(f'Unsupported lineage version: {lineage["version"]}', file=sys.stderr)
 END_OF_LINE
 )"
+
+# Install all necessary mypy type stubs
+mypy --install-types --non-interactive src/
 
 # Qapla'
 echo "Success!"

--- a/setup-env
+++ b/setup-env
@@ -251,7 +251,7 @@ for req_file in "requirements-dev.txt" "requirements-test.txt" "requirements.txt
 done
 
 # Install all necessary mypy type stubs
-mypy --install-types src/
+mypy --install-types --non-interactive src/
 
 # Install git pre-commit hooks now or later.
 pre-commit install ${INSTALL_HOOKS:+"--install-hooks"}


### PR DESCRIPTION
## 🗣 Description ##

This pull reques
- Adds the `--non-interactive` flag when installing type stubs via `mypy`
- Moves the `mypy` command toward the end of the `setup-env` script

## 💭 Motivation and context ##

- This flag forces `mypy` to hide the errors about missing stubs and instead simply install stubs without asking for confirmation.  It also does not return an error code, which it does without this flag _even if you opt to let it install the missing type stubs_.
- Moving the `mypy` command toward the end of the `setup-env` script ensures that, should the command fail, all the other good stuff in the script will still happen.

## 🧪 Testing ##

All automated tests pass.  These changes were tested as part of cisagov/cyhy-config#5.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.