### PR TITLE
Improve pytest configuration

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
-addopts = -v -ra --cov
+# Increase verbosity, display extra test summary info for tests that did not pass,
+# display code coverage results, and enable debug logging
+addopts = --verbose -ra --cov --log-cli-level=DEBUG


### PR DESCRIPTION


# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR improves the pytest configuration by:
* Using long flag names when possible
* Enabling debug [logging](https://docs.pytest.org/en/latest/how-to/logging.html).
* Adding a helpful explanatory comment
 
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

All of these changes add up to a more readable configuration file and more useful output during test runs.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

This pytest configuration change was tested as part of https://github.com/cisagov/cyhy-config/pull/5.

Note that https://github.com/cisagov/skeleton-aws-lambda-python/pull/33 is a similar PR.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
