### PR TITLE
Add `dev` dependencies section

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -156,6 +156,7 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
+          - types-docopt
           - types-setuptools
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.15.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -155,6 +155,10 @@ repos:
     rev: v1.10.0
     hooks:
       - id: mypy
+        # IMPORTANT: Keep type hinting-related dependencies of the
+        # mypy pre-commit hook additional_dependencies in sync with
+        # the dev section of setup.py to avoid discrepancies in type
+        # checking between environments.
         additional_dependencies:
           - types-docopt
           - types-setuptools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+--editable .[dev]
 --requirement requirements-test.txt
 ipython
 mypy

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,16 @@ setup(
     include_package_data=True,
     install_requires=["docopt", "schema", "setuptools >= 24.2.0"],
     extras_require={
+        # IMPORTANT: Keep type hinting-related dependencies of the dev section
+        # in sync with the mypy pre-commit hook configuration (see
+        # .pre-commit-config.yaml). Any changes to type hinting-related
+        # dependencies here should be reflected in the additional_dependencies
+        # field of the mypy pre-commit hook to avoid discrepancies in type
+        # checking between environments.
+        "dev": [
+            "types-docopt",
+            "types-setuptools",
+        ],
         "test": [
             "coverage",
             # coveralls 1.11.0 added a service number for calls from
@@ -105,7 +115,7 @@ setup(
             "pre-commit",
             "pytest-cov",
             "pytest",
-        ]
+        ],
     },
     # Conveniently allows one to run the CLI tool as `example`
     entry_points={"console_scripts": ["example = example.example:main"]},

--- a/src/example/example.py
+++ b/src/example/example.py
@@ -28,7 +28,10 @@ from typing import Any, Dict
 # Third-Party Libraries
 import docopt
 import pkg_resources
-from schema import And, Schema, SchemaError, Use
+
+# There are no type stubs for the schema library, so mypy requires the type:
+# ignore hint.
+from schema import And, Schema, SchemaError, Use  # type: ignore
 
 from ._version import __version__
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a `dev` section to `extras_require` for type stub dependencies.

## 💭 Motivation and context ##

We want folks to be able to set up their development environment using `setup.py`.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.