### PR TITLE
Remove two unnecessary pins

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,17 +91,11 @@ setup(
     package_data={"example": ["data/*.txt"]},
     py_modules=[splitext(basename(path))[0] for path in glob("src/*.py")],
     include_package_data=True,
-    install_requires=["docopt", "schema", "setuptools >= 24.2.0"],
+    install_requires=["docopt", "schema", "setuptools"],
     extras_require={
         "test": [
             "coverage",
-            # coveralls 1.11.0 added a service number for calls from
-            # GitHub Actions. This caused a regression which resulted in a 422
-            # response from the coveralls API with the message:
-            # Unprocessable Entity for url: https://coveralls.io/api/v1/jobs
-            # 1.11.1 fixed this issue, but to ensure expected behavior we'll pin
-            # to never grab the regression version.
-            "coveralls != 1.11.0",
+            "coveralls",
             "pre-commit",
             "pytest-cov",
             "pytest",


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes two pins in `setup.py` that are now unnecessary.

## 💭 Motivation and context ##

- The `setuptools` pin was enforcing a version newer than a version from 2016, which seems unnecessary since we are only supporting Python 3.7 and up.
- The `coveralls` pin was enforcing that we not install a particular version from 2020.  This again seems unnecessary as we are only supporting Python 3.7 and up.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.