### PR TITLE
Upgrade GH Action in CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
           egress-policy: audit
       - id: github-status
         name: Check GitHub status
-        uses: crazy-max/ghaction-github-status@v3
+        uses: crazy-max/ghaction-github-status@v4
       - id: dump-context
         name: Dump context
         uses: crazy-max/ghaction-dump-context@v2


### PR DESCRIPTION
## 🗣 Description ##

This pull request bumps the version of [crazy-max/ghaction-github-status](https://github.com/crazy-max/ghaction-github-status) from 3 to 4 in the CodeQL GitHub Actions workflow.

## 💭 Motivation and context ##

We are using [`crazy-max/ghaction-github-status@v4`](https://github.com/crazy-max/ghaction-github-status) in our other workflows, so we should use it in this one too.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
