### PR TITLE
Adjust how package data is accessed

### DIFF
--- a/src/example/_version.py
+++ b/src/example/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/src/example/data/__init__.py
+++ b/src/example/data/__init__.py
@@ -1,5 +1,0 @@
-"""The example.data package."""
-
-# This is necessary for the secret_message line using importlib to correctly
-# work with Python 3.9.  See here for more details:
-# https://setuptools.pypa.io/en/latest/userguide/datafiles.html?utm_source=chatgpt.com#namespace-support

--- a/src/example/example.py
+++ b/src/example/example.py
@@ -96,7 +96,7 @@ def main() -> None:
 
     # Access some data from our package data (see the setup.py)
     secret_message: str = (
-        files(__package__).joinpath("data/secret.txt").read_text().strip()
+        files(__package__).joinpath("data", "secret.txt").read_text().strip()
     )
     logging.info('Secret="%s"', secret_message)
 

--- a/src/example/example.py
+++ b/src/example/example.py
@@ -96,7 +96,7 @@ def main() -> None:
 
     # Access some data from our package data (see the setup.py)
     secret_message: str = (
-        files(f"{__package__}.data").joinpath("secret.txt").read_text().strip()
+        files(__package__).joinpath("data/secret.txt").read_text().strip()
     )
     logging.info('Secret="%s"', secret_message)
 


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates how package data is accessed to remove the empty `example.data` package and instead treat `data/secret.txt` as a resource of the `example` package.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This reduces clutter from sub-packages that are just file containers and logically follows how the package contents are laid out in the filesystem.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
