### PR TITLE
Allow *any* changes in `tests` directory to trigger `test` label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -60,7 +60,7 @@ test:
           - .mdl_config.yaml
           - .yamllint
           - pytest.ini
-          - tests/**/*.py
+          - tests/**
 typescript:
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the `labeler.yml` configuration file to allow *any* changes in the `tests` directory to trigger the `test` label.

## 💭 Motivation and context ##

@mcdonnnj pointed this out [while reviewing cisagov/action-lineage#84](https://github.com/cisagov/action-lineage/pull/84#discussion_r2417819874).

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.