### PR TITLE
Remove an unnecessary dev dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -169,11 +169,10 @@ repos:
       - id: mypy
         # IMPORTANT: Keep type hinting-related dependencies of the
         # mypy pre-commit hook additional_dependencies in sync with
-        # the dev section of setup.py to avoid discrepancies in type
-        # checking between environments.
+        # the dev section of pyproject.toml to avoid discrepancies in
+        # type checking between environments.
         additional_dependencies:
           - types-docopt
-          - types-setuptools
   - repo: https://github.com/pypa/pip-audit
     rev: v2.9.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ requires-python = ">=3.10"
 # checking between environments.
 dev = [
     "types-docopt",
-    "types-setuptools",
 ]
 test = [
     "coverage",


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes the `types-setuptools` library as a `dev` dependency.

## 💭 Motivation and context ##

`types-setuptools` is not necessary here since we are not interfacing with `setuptools` directly.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.