### PR TITLE
Add `build` and `twine` as `dev` dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ requires-python = ">=3.10"
 # field of the mypy pre-commit hook to avoid discrepancies in type
 # checking between environments.
 dev = [
+    "build",
+    "twine",
     "types-docopt",
     "types-setuptools",
 ]


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds two `dev` dependencies that are sometimes useful.

## 💭 Motivation and context ##

I occasionally need to run `python -m build` to debug an issue with a wheel.  `twine` seems good to include too, since folks may want to upload to Test PyPI or PyPI.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.