### PR TITLE
Add lower bound for `setuptools`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,13 @@
 # https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools"]
+requires = [
+    # 61.0 was the first version of setuptools to offer a full-fledged
+    # backend that uses pyproject.toml for metadata configuration (in
+    # compliance with PEP 621):
+    # https://setuptools.pypa.io/en/stable/history.html#v61-0-0
+    "setuptools>=61.0"
+]
 
 [project]
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,15 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-    # 61.0 was the first version of setuptools to offer a full-fledged
+    # 61.0.0 was the first version of setuptools to offer a full-fledged
     # backend that uses pyproject.toml for metadata configuration (in
     # compliance with PEP 621):
     # https://setuptools.pypa.io/en/stable/history.html#v61-0-0
-    "setuptools>=61.0"
+    #
+    # 77.0.0 was the first version of setuptools to support license
+    # expressions (in compliance with PEP 639):
+    # https://setuptools.pypa.io/en/stable/history.html#v77-0-0
+    "setuptools>=77.0.0"
 ]
 
 [project]


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a lower bound for `setuptools` to support `pyproject.toml` and the features we use therein.

## 💭 Motivation and context ##

This ensures that the `pyproject.toml` build backend supports our `pyproject.toml` configuration.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.