### PR TITLE
Add workflow code to generate SBOMs and upload them to the release/pre-release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,8 +23,10 @@ updates:
       - dependency-name: hashicorp/setup-terraform
       - dependency-name: mxschmitt/action-tmate
       # # Managed by cisagov/skeleton-python-library
+      # - dependency-name: actions/attest-build-provenance
       # - dependency-name: actions/download-artifact
       # - dependency-name: actions/upload-artifact
+      # - dependency-name: anchore/sbom-action
     labels:
       # dependabot default we need to replicate
       - dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
       - dependency-name: hashicorp/setup-terraform
       - dependency-name: mxschmitt/action-tmate
       # # Managed by cisagov/skeleton-python-library
-      # - dependency-name: actions/attest-build-provenance
+      # - dependency-name: actions/attest
       # - dependency-name: actions/download-artifact
       # - dependency-name: actions/upload-artifact
       # - dependency-name: anchore/sbom-action

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -530,7 +530,7 @@ jobs:
     if: github.event_name != 'pull_request'
     name: Generate and upload SBOM
     needs:
-      - build
+      - build-wheel
       - diagnostics
     permissions:
       # Allows us to read the SBOM artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,14 +126,11 @@ jobs:
             packer${{ steps.setup-env.outputs.packer-version }}-\
             tf${{ steps.setup-env.outputs.terraform-version }}-
         with:
-          # We do not use '**/setup.py' in the cache key so only the 'setup.py'
-          # file in the root of the repository is used. This is in case a Python
-          # package were to have a 'setup.py' as part of its internal codebase.
           key: ${{ env.BASE_CACHE_KEY }}\
             ${{ hashFiles('**/requirements-test.txt') }}-\
             ${{ hashFiles('**/requirements.txt') }}-\
             ${{ hashFiles('**/.pre-commit-config.yaml') }}-\
-            ${{ hashFiles('setup.py') }}
+            ${{ hashFiles('pyproject.toml') }}
           # Note that the .terraform directory IS NOT included in the
           # cache because if we were caching, then we would need to use
           # the `-upgrade=true` option. This option blindly pulls down the
@@ -263,13 +260,10 @@ jobs:
             py${{ steps.setup-python.outputs.python-version }}-
         with:
           path: ${{ env.PIP_CACHE_DIR }}
-          # We do not use '**/setup.py' in the cache key so only the 'setup.py'
-          # file in the root of the repository is used. This is in case a Python
-          # package were to have a 'setup.py' as part of its internal codebase.
           key: ${{ env.BASE_CACHE_KEY }}\
             ${{ hashFiles('**/requirements-test.txt') }}-\
             ${{ hashFiles('**/requirements.txt') }}-\
-            ${{ hashFiles('setup.py') }}
+            ${{ hashFiles('pyproject.toml') }}
           restore-keys: |
             ${{ env.BASE_CACHE_KEY }}
       - name: Install dependencies
@@ -389,12 +383,9 @@ jobs:
             py${{ steps.setup-python.outputs.python-version }}-
         with:
           path: ${{ env.PIP_CACHE_DIR }}
-          # We do not use '**/setup.py' in the cache key so only the 'setup.py'
-          # file in the root of the repository is used. This is in case a Python
-          # package were to have a 'setup.py' as part of its internal codebase.
           key: ${{ env.BASE_CACHE_KEY }}\
             ${{ hashFiles('**/requirements.txt') }}-\
-            ${{ hashFiles('setup.py') }}
+            ${{ hashFiles('pyproject.toml') }}
           restore-keys: |
             ${{ env.BASE_CACHE_KEY }}
       - name: Install build dependencies
@@ -475,12 +466,9 @@ jobs:
             py${{ steps.setup-python.outputs.python-version }}-
         with:
           path: ${{ env.PIP_CACHE_DIR }}
-          # We do not use '**/setup.py' in the cache key so only the 'setup.py'
-          # file in the root of the repository is used. This is in case a Python
-          # package were to have a 'setup.py' as part of its internal codebase.
           key: ${{ env.BASE_CACHE_KEY }}\
             ${{ hashFiles('**/requirements.txt') }}-\
-            ${{ hashFiles('setup.py') }}
+            ${{ hashFiles('pyproject.toml') }}
           restore-keys: |
             ${{ env.BASE_CACHE_KEY }}
       - name: Retrieve the built wheel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -613,7 +613,7 @@ jobs:
         name: Get the name of the retrieved wheel (there should only be one)
         run: echo "wheel=$(ls dist/*whl)" >> $GITHUB_OUTPUT
       - name: Update core Python packages
-        run: python -m pip install --upgrade pip setuptools wheel
+        run: python -m pip install --upgrade pip setuptools
       - name: Install pipenv
         run: pip install --upgrade pipenv
       - name: Install the built wheel into a Pipfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -338,9 +338,9 @@ jobs:
       # Necessary to create the artifact storage record
       artifact-metadata: write
       attestations: write
-      # Allows us to add the SBOM to the release.  Also,
-      # actions/checkout needs read permission to fetch code.
-      contents: write
+      # Allows actions/checkout to fetch code; write access is not
+      # required for this build job.
+      contents: read
       # Allows the workflow to mint the OIDC token necessary to
       # request a Sigstore signing certificate.
       id-token: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -589,14 +589,27 @@ jobs:
         run: pipenv install ${{ steps.find-wheel.outputs.wheel }}
       - name: Lock the Pipfile
         run: pipenv lock
-      - name: Gemerate SBOM
+      - name: Manipulate the repo name into the preferred format
+        id: manipulate-repo-name
+        run: |
+          NEW_NAME=$(echo "${{ github.repository}}" \
+          | tr '[:upper:]' '[:lower:]' \
+          | tr '/ ' '-')
+          echo "repo-name=${NEW_NAME}" >> $GITHUB_OUTPUT
+      - name: Generate SBOM
         uses: anchore/sbom-action@v0
         with:
-          artifact-name: sbom.py${{ matrix.python-version }}.${{ matrix.sbom-format }}
+          artifact-name: >-
+            ${{ steps.manipulate-repo-name.outputs.repo-name }}.py${{
+            matrix.python-version }}.${{ matrix.sbom-format }}
           file: Pipfile.lock
           format: ${{ matrix.sbom-format }}
-          output-file: sbom.py${{ matrix.python-version }}.${{ matrix.sbom-format }}
+          output-file: >-
+            ${{ steps.manipulate-repo-name.outputs.repo-name }}.py${{
+            matrix.python-version }}.${{ matrix.sbom-format }}
       - name: Attest build provenance for the SBOM
         uses: actions/attest-build-provenance@v3
         with:
-          subject-path: sbom.py${{ matrix.python-version }}.${{ matrix.sbom-format }}
+          subject-path: >-
+            ${{ steps.manipulate-repo-name.outputs.repo-name }}.py${{
+            matrix.python-version }}.${{ matrix.sbom-format }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -612,9 +612,10 @@ jobs:
           output-file: >-
             ${{ steps.manipulate-repo-name.outputs.repo-name }}.py${{
             matrix.python-version }}.${{ matrix.sbom-format }}
-      - name: Attest build provenance for the SBOM
-        uses: actions/attest-build-provenance@v3
+      - name: Create SBOM attestation
+        uses: actions/attest@v4
         with:
-          subject-path: >-
+          sbom-path: >-
             ${{ steps.manipulate-repo-name.outputs.repo-name }}.py${{
             matrix.python-version }}.${{ matrix.sbom-format }}
+          subject-path: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -499,6 +499,9 @@ jobs:
     # been generated in the build job.  Putting it in a separate
     # release workflow would require us to introduce a dependency of
     # the release workflow on this one.
+    #
+    # This if statement is present to keep the push and pull_request
+    # events from both causing the job to be run.
     if: github.event_name != 'pull_request'
     name: Generate and upload SBOM
     needs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -491,8 +491,8 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE
   generate-sbom:
-    # Generate SBOMs for the built Python wheel packages and, if there is a
-    # release, upload them as assets to the release.
+    # Generate SBOMs for the built Python wheel packages and, if there
+    # is a release, upload them as assets to the release.
     #
     # This job is located in this workflow as opposed to a separate
     # release workflow because it can only run after the wheels have

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -510,6 +510,7 @@ jobs:
     permissions:
       # Allows us to read the SBOM artifact
       actions: read
+      # Necessary to create the artifact storage record
       artifact-metadata: write
       attestations: write
       # Allows us to add the SBOM to the release.  Also,
@@ -612,7 +613,13 @@ jobs:
           output-file: >-
             ${{ steps.manipulate-repo-name.outputs.repo-name }}.py${{
             matrix.python-version }}.${{ matrix.sbom-format }}
-      - name: Create SBOM attestation
+      - name: Create provenance attestation for SBOM
+        uses: actions/attest@v4
+        with:
+          subject-path: >-
+            ${{ steps.manipulate-repo-name.outputs.repo-name }}.py${{
+            matrix.python-version }}.${{ matrix.sbom-format }}
+      - name: Create SBOM attestation for distribution package
         uses: actions/attest@v4
         with:
           sbom-path: >-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -491,8 +491,8 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE
   generate-sbom:
-    # Generate an SBOM for the Docker image and, if there is a
-    # release, upload it as an asset to the release.
+    # Generate SBOMs for the built Python wheel packages and, if there is a
+    # release, upload them as assets to the release.
     #
     # This job is located in this workflow as opposed to a separate
     # release workflow because it can only run after the wheels have

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -565,7 +565,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         env:
           BASE_CACHE_KEY: ${{ github.job }}-\
             ${{ runner.os }}-${{ runner.arch }}-\

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -606,7 +606,7 @@ jobs:
           restore-keys: |
             ${{ env.BASE_CACHE_KEY }}
       - name: Retrieve the built wheel
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: dist-${{ matrix.python-version }}
           path: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -567,13 +567,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - uses: actions/cache@v5
         env:
-          BASE_CACHE_KEY: ${{ github.job }}-\
-            ${{ runner.os }}-${{ runner.arch }}-\
-            py${{ matrix.python-version }}-
+          BASE_CACHE_KEY: >-
+            ${{ github.job }}-${{
+            runner.os }}-${{ runner.arch }}-py${{
+            matrix.python-version }}-
         with:
           path: ${{ env.PIP_CACHE_DIR }}
-          key: ${{ env.BASE_CACHE_KEY }}\
-            ${{ hashFiles('pyproject.toml') }}
+          key: >-
+            ${{ env.BASE_CACHE_KEY }}${{
+            hashFiles('pyproject.toml') }}
           restore-keys: |
             ${{ env.BASE_CACHE_KEY }}
       - name: Retrieve the built wheel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -333,8 +333,17 @@ jobs:
       - lint
       - test
     permissions:
-      # actions/checkout needs this to fetch code
-      contents: read
+      # Allows us to read artifacts
+      actions: read
+      # Necessary to create the artifact storage record
+      artifact-metadata: write
+      attestations: write
+      # Allows us to add the SBOM to the release.  Also,
+      # actions/checkout needs read permission to fetch code.
+      contents: write
+      # Allows the workflow to mint the OIDC token necessary to
+      # request a Sigstore signing certificate.
+      id-token: write
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -399,6 +408,10 @@ jobs:
         with:
           name: dist-${{ matrix.python-version }}
           path: dist
+      - name: Create provenance attestation for distribution
+        uses: actions/attest@v4
+        with:
+          subject-path: dist
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -564,12 +564,12 @@ jobs:
       - id: setup-python
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ steps.setup-env.outputs.python-version }}
+          python-version: ${{ matrix.python-version }}
       - uses: actions/cache@v4
         env:
           BASE_CACHE_KEY: ${{ github.job }}-\
             ${{ runner.os }}-${{ runner.arch }}-\
-            py${{ steps.setup-python.outputs.python-version }}-
+            py${{ matrix.python-version }}-
         with:
           path: ${{ env.PIP_CACHE_DIR }}
           key: ${{ env.BASE_CACHE_KEY }}\

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -490,3 +490,113 @@ jobs:
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE
+  generate-sbom:
+    # Generate an SBOM for the Docker image and, if there is a
+    # release, upload it as an asset to the release.
+    #
+    # This job is located in this workflow as opposed to a separate
+    # release workflow because it can only run after the wheels have
+    # been generated in the build job.  Putting it in a separate
+    # release workflow would require us to introduce a dependency of
+    # the release workflow on this one.
+    if: github.event_name != 'pull_request'
+    name: Generate and upload SBOM
+    needs:
+      - build
+      - diagnostics
+    permissions:
+      # Allows us to read the SBOM artifact
+      actions: read
+      artifact-metadata: write
+      attestations: write
+      # Allows us to add the SBOM to the release.  Also,
+      # actions/checkout needs read permission to fetch code.
+      contents: write
+      # Allows the workflow to mint the OIDC token necessary to
+      # request a Sigstore signing certificate.
+      id-token: write
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+        sbom-format:
+          - cyclonedx-json
+          - spdx-json
+    steps:
+      - name: Apply standard cisagov job preamble
+        uses: cisagov/action-job-preamble@v1
+        with:
+          # This functionality is poorly implemented and has been
+          # causing problems due to the MITM implementation hogging or
+          # leaking memory.  As a result we disable it by default.  If
+          # you want to temporarily enable it, simply set
+          # monitor_permissions equal to "true".
+          #
+          # TODO: Re-enable this functionality when practical.  See
+          # cisagov/skeleton-docker#224 for more details.
+          monitor_permissions: "false"
+          # Use a variable to specify the permissions monitoring
+          # configuration. By default this will yield the
+          # configuration stored in the cisagov organization-level
+          # variable, but if you want to use a different configuration
+          # then simply:
+          # 1. Create a repository-level variable with the name
+          # ACTIONS_PERMISSIONS_CONFIG.
+          # 2. Set this new variable's value to the configuration you
+          # want to use for this repository.
+          #
+          # Note in particular that changing the permissions
+          # monitoring configuration *does not* require you to modify
+          # this workflow.
+          permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+      - id: setup-env
+        uses: cisagov/setup-env-github-action@v1
+      - uses: actions/checkout@v6
+      - id: setup-python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ steps.setup-env.outputs.python-version }}
+      - uses: actions/cache@v4
+        env:
+          BASE_CACHE_KEY: ${{ github.job }}-\
+            ${{ runner.os }}-${{ runner.arch }}-\
+            py${{ steps.setup-python.outputs.python-version }}-
+        with:
+          path: ${{ env.PIP_CACHE_DIR }}
+          key: ${{ env.BASE_CACHE_KEY }}\
+            ${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ env.BASE_CACHE_KEY }}
+      - name: Retrieve the built wheel
+        uses: actions/download-artifact@v7
+        with:
+          name: dist-${{ matrix.python-version }}
+          path: dist
+      - id: find-wheel
+        name: Get the name of the retrieved wheel (there should only be one)
+        run: echo "wheel=$(ls dist/*whl)" >> $GITHUB_OUTPUT
+      - name: Update core Python packages
+        run: python -m pip install --upgrade pip setuptools wheel
+      - name: Install pipenv
+        run: pip install --upgrade pipenv
+      - name: Install the built wheel into a Pipfile
+        run: pipenv install ${{ steps.find-wheel.outputs.wheel }}
+      - name: Lock the Pipfile
+        run: pipenv lock
+      - name: Gemerate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          artifact-name: sbom.py${{ matrix.python-version }}.${{ matrix.sbom-format }}
+          file: Pipfile.lock
+          format: ${{ matrix.sbom-format }}
+          output-file: sbom.py${{ matrix.python-version }}.${{ matrix.sbom-format }}
+      - name: Attest build provenance for the SBOM
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: sbom.py${{ matrix.python-version }}.${{ matrix.sbom-format }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
 
   # GitHub Actions hooks
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.35.0
+    rev: 0.36.1
     hooks:
       - id: check-github-actions
       - id: check-github-workflows


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Adds workflow code to generate SBOMs for the Python distribution package
- If we happen to be building a release or pre-release then the SBOMs will be uploaded to the release or pre-release.
- Adds workflow code to create provenance attestations for the SBOMs and the Python distribution package
- Adds workflow code to create SBOM attestations for the Python distribution package

## 💭 Motivation and context ##

CISA advocates for the use of SBOMs, so we should be generating them for our software products.

Resolves #178.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [ ] Mark SBOM checks as required.