### PR TITLE
Adjust job configurations in the `build` workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,7 +204,7 @@ jobs:
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE
-  test:
+  test-source:
     name: test source - py${{ matrix.python-version }} - ${{ matrix.platform }}
     needs:
       - diagnostics
@@ -299,7 +299,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - diagnostics
-      - test
+      - test-source
     steps:
       - name: Apply standard cisagov job preamble
         uses: cisagov/action-job-preamble@v1
@@ -335,7 +335,7 @@ jobs:
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE
-  build:
+  build-wheel:
     name: build wheel - py${{ matrix.python-version }}
     needs:
       - diagnostics
@@ -411,12 +411,12 @@ jobs:
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE
-  test-build:
+  test-wheel:
     name: test built wheel - py${{ matrix.python-version }} - ${{ matrix.platform }}
     needs:
       - diagnostics
-      - build
-      - test
+      - build-wheel
+      - test-source
     permissions:
       # actions/checkout needs this to fetch code
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -339,8 +339,6 @@ jobs:
     name: build wheel - py${{ matrix.python-version }}
     needs:
       - diagnostics
-      - lint
-      - test
     permissions:
       # actions/checkout needs this to fetch code
       contents: read
@@ -418,6 +416,7 @@ jobs:
     needs:
       - diagnostics
       - build
+      - test
     permissions:
       # actions/checkout needs this to fetch code
       contents: read


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adjust the job configurations in the `build` workflow by renaming some jobs and adjusting job dependencies.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Job names are changed to better align with their descriptive names and their respective functionality. Dependencies are modified so that the workflow attempts to build wheels no matter what, but testing those wheels is only done if it is able to successfully test the source (and wheels have been built successfully).
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
