### PR TITLE
Group the upload-artifact and download-artifact actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@
 
 updates:
   - directory: /
+    groups:
+      upload-download-artifact:
+        patterns:
+          - actions/download-artifact
+          - actions/upload-artifact
     ignore:
       # Managed by cisagov/skeleton-generic
       - dependency-name: actions/cache


### PR DESCRIPTION
## 🗣 Description ##

This pull request groups the `actions/upload-artifact` and `actions/download-artifact` GitHub actions dependencies.

## 💭 Motivation and context ##

These two actions often need to be upgraded in lockstep, so it makes sense to group them.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.