### PR TITLE
Add (commented-out) Dependabot ignore directives for Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,9 +41,6 @@ updates:
       interval: weekly
 
   - directory: /
-    package-ecosystem: pip
-    schedule:
-      interval: weekly
     # ignore:
     #   # Managed by cisagov/skeleton-python-library
     #   - dependency-name: build
@@ -54,6 +51,9 @@ updates:
     #   - dependency-name: pytest
     #   - dependency-name: setuptools
     #   - dependency-name: twine
+    package-ecosystem: pip
+    schedule:
+      interval: weekly
 
   - directory: /
     package-ecosystem: terraform

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,16 @@ updates:
     package-ecosystem: pip
     schedule:
       interval: weekly
+    # ignore:
+    #   # Managed by cisagov/skeleton-python-library
+    #   - dependency-name: build
+    #   - dependency-name: coverage
+    #   - dependency-name: coveralls
+    #   - dependency-name: pre-commit
+    #   - dependency-name: pytest-cov
+    #   - dependency-name: pytest
+    #   - dependency-name: setuptools
+    #   - dependency-name: twine
 
   - directory: /
     package-ecosystem: terraform


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds some commented-out Dependabot ignore directives for dependencies that are handled in the Lineage parent repository.

## 💭 Motivation and context ##

This is being done so that descendant repositories can uncomment these for Python dependencies such as `setuptools` that are really inherited from the Lineage parent repository.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
