### PR TITLE
Add `semver` to Dependabot ignore directives

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,7 @@ updates:
     #   - dependency-name: pre-commit
     #   - dependency-name: pytest-cov
     #   - dependency-name: pytest
+    #   - dependency-name: semver
     #   - dependency-name: setuptools
     #   - dependency-name: twine
     package-ecosystem: pip


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds `semver` to the (commented-out) Dependabot ignore directives.

## 💭 Motivation and context ##

This was somehow missed in #188.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.